### PR TITLE
Unify original vendor name and package name to "Php.Skeleton"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project name="PHP.Skeleton" default="build">
+<project name="Php.Skeleton" default="build">
     <property name="composer.path" value="${basedir}/composer.phar" />
     <available property="composer.exists" file="${composer.path}" />
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="BEAR">
-    <description>The BEAR coding standard.</description>
+<ruleset name="Php.Skeleton">
+    <description>The Php.Skeleton coding standard.</description>
     <!-- 2. General -->
     <rule ref="Generic.NamingConventions.UpperCaseConstantName">
         <exclude name="Generic.NamingConventions.UpperCaseConstantName.ConstantNotUpperCase"/>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,9 +1,9 @@
-<ruleset name="PHP.Skeleton rules"
+<ruleset name="Php.Skeleton rules"
          xmlns="http://pmd.sf.net/ruleset/1.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
          xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
-    <description>PHP.Skeleton rule set</description>
+    <description>Php.Skeleton rule set</description>
     <!--codesize-->
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity" />
     <rule ref="rulesets/codesize.xml/NPathComplexity" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,13 +7,13 @@
          verbose="true"
 		 colors="true">
   <testsuites>
-    <testsuite name="PHP.Skelton">
+    <testsuite name="Php.Skeleton">
       <directory suffix="Test.php">tests</directory>
     </testsuite>
   </testsuites>
 
   <logging>
-    <log type="coverage-html" target="build/coverage" title="PHP.Skelton"
+    <log type="coverage-html" target="build/coverage" title="Php.Skeleton"
          charset="UTF-8" yui="true" highlight="true"
          lowUpperBound="35" highLowerBound="70"/>
     <log type="coverage-clover" target="build/logs/clover.xml"/>


### PR DESCRIPTION
Unifying original vendor name and package name to "Php.Skeleton".

This is intended to replace to the user's vendor and package name on install script (another PR #7)
