### PR TITLE
Fix folder name validation

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -16,11 +16,11 @@ class Installer
         $skeletonRoot = dirname(__DIR__);
         $splFile = new \SplFileInfo($skeletonRoot);
         $folderName = $splFile->getFilename();
-        list($vendorName, $packageName) = explode('.', $folderName);
         $appNameRegex = '/^[A-Za-z0-9]+\.[A-Za-z0-9]+$/';
         if (! preg_match($appNameRegex, $folderName)) {
           throw new \LogicException('Package name must be in the format "Vendor.Application".');
         }
+        list($vendorName, $packageName) = explode('.', $folderName);
         $jobChmod = function (\SplFileInfo $file) {
             chmod($file, 0777);
         };


### PR DESCRIPTION
Fix the error message:

```
  [ErrorException]     
  Undefined offset: 1  
```

But ideally this validation should be done on `pre-install-cmd`.
