### PR TITLE
Fix composer.json syntax (autoload-dev)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
             "__Vendor__\\__Package__\\": "src/"
         }
     },
+    "autoload-dev":{
+        "psr-4":{
+            "__Vendor__\\__Package__\\": ["tests/", "tests/Fake"]
+        }
+    },
     "scripts"   :{
         "post-install-cmd": "__Vendor__\\__Package__\\Installer::postInstall"
     },

--- a/composer.json.dist
+++ b/composer.json.dist
@@ -11,8 +11,7 @@
     },
     "autoload-dev":{
         "psr-4":{
-            "__Vendor__\\__Package__\\": "tests/",
-            "__Vendor__\\__Package__\\": "tests/Fake"
+            "__Vendor__\\__Package__\\": ["tests/", "tests/Fake"]
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
## 変更内容
- Fix composer.json.dist JSON syntax
- 変換元である composer.json の autoload-dev と変換設定の composer.json.dist の autoload-dev で項目が一致していなかったので、composer.json.dist の方に合わせるようにしました

（※余談：個人的には、Fake は使っていないですが。）
#### 動作検証メモ

下記のとおり動作確認済みです。
- [x] スケルトン作成できること
- [x] create-project するだけで（composer dump-autoload をすることなく）、`Fake`のパスがオートロード登録されていること
- 検証環境

`package.json`

```
{
    "package": {
        "name": "php/skeleton",
        "version": "1.0.0",
        "source": {
            "url": "https://github.com/kumamidori/PHP.Skeleton.git",
            "type": "git",
            "reference": "feature/fix_composer_json_skeleton"
        }
    }
}
```

```
composer create-project --stability="dev" --repository-url="/path/to/my/PHP.Skeleton/package.json" php/skeleton MyVendor.MyPackage
```
