### PR TITLE
Fix unlink composer.lock error

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -45,7 +45,6 @@ class Installer
 
         // composer.json
         unlink("{$skeletonRoot}/composer.json");
-        unlink("{$skeletonRoot}/composer.lock");
         $jobRename(new \SplFileInfo("{$skeletonRoot}/composer.json.dist"));
         rename("{$skeletonRoot}/composer.json.dist", "{$skeletonRoot}/composer.json");
 


### PR DESCRIPTION
最新版でスケルトン作成を実行すると、下記エラーが出るようになったのを直しました。
動作確認済みです。:ram:

```
  [ErrorException]
  unlink(/my/path/to/composer.lock): No such file or directory
```
