### PR TITLE
Fix for Composer spec change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     },
     "scripts" :{
         "pre-install-cmd": ["PHP\\Skeleton\\Installer::preInstall"],
-        "post-install-cmd": [
+        "pre-update-cmd": ["PHP\\Skeleton\\Installer::preInstall"],
+        "post-create-project-cmd": [
             "PHP\\Skeleton\\Installer::postInstall",
             "composer update"
         ],

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -97,7 +97,8 @@ class Installer
         $composerDefinition = $json->read();
         unset($composerDefinition['autoload']['files']);
         unset($composerDefinition['scripts']['pre-install-cmd']);
-        unset($composerDefinition['scripts']['post-install-cmd']);
+        unset($composerDefinition['scripts']['pre-update-cmd']);
+        unset($composerDefinition['scripts']['post-create-project-cmd']);
         $composerDefinition['name'] = $packageName;
         $composerDefinition['authors'] = [['name' => self::$name]];
         $composerDefinition['description'] = '';


### PR DESCRIPTION
"pre-install-cmd" is for old composer command.

See https://github.com/composer/composer/issues/5066#issuecomment-197006540.
