### PR TITLE
Avoid apigen error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
             "pdepend --jdepend-xml=./build/logs/jdepend.xml --jdepend-chart=./build/pdepend/dependencies.svg --overview-pyramid=./build/pdepend/overview-pyramid.svg src",
             "phploc --log-csv ./build/logs/phploc.csv src",
             "phpcs --report=checkstyle --report-file=./build/logs/checkstyle.xml --standard=phpcs.xml src",
-            "apigen generate -s src -d build/api --debug",
+            "apigen generate -s src -d build/api",
             "@test"
         ]
     },


### PR DESCRIPTION
avoid apigen error as below.

```
ErrorException: Nette\DI\ServiceDefinition::getImplementType() is deprecated, use getImplementMode()
```
