### PR TITLE
get user.name and user.email from "git config" without --global too

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -130,14 +130,14 @@ class Installer
 
     private static function getUserName() : string
     {
-        $author = shell_exec('git config --global user.name');
+        $author = shell_exec('git config --global user.name || git config user.name');
 
         return $author ? trim($author) : '';
     }
 
     private static function getUserEmail() : string
     {
-        $email = shell_exec('git config --global user.email');
+        $email = shell_exec('git config --global user.email || git config user.email');
 
         return $email ? trim($email) : '';
     }


### PR DESCRIPTION
in my environment

there are like this.

```
kurari at sandisk-extreme-portable-500 in ~/avap/Koriym.PhpSkeleton (1.x)
$ git config --global user.name

kurari at sandisk-extreme-portable-500 in ~/avap/Koriym.PhpSkeleton (1.x)
$ git config  user.name
Hajime MATSUMOTO
```

so, I added to retry user.name from "git config" without `--global` too 
