### PR TITLE
Add `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# https://php.watch/articles/composer-gitattributes
+
+# Exclude build/test files from archive
+/tests            export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml      export-ignore
+/codecov.yml      export-ignore
+/phpcs.xml        export-ignore
+/phpmd.xml        export-ignore
+/phpstan.neon     export-ignore
+/phpunit.xml.dist export-ignore
+
+# Configure diff output for .php and .phar files.
+*.php diff=php
+*.phar -diff


### PR DESCRIPTION
Adds a `.gitattributes` file with `export-ignore` and `diff` rules [suitable for composer projects](https://php.watch/articles/composer-gitattributes)

Creating a project with `composer create-project` still clones the entire repository, so all files get downloaded. However, when the package is published, consumers of that package will not get the build files if they download it with `prefer-dist`, which is the default.
This can reduce the download size of packages by a significant percentage.