### PR TITLE
PHP7.2 is no longer supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",


### PR DESCRIPTION
Since phpunit:^9.5 requires php:^7.3 ( https://phpunit.de/announcements/phpunit-9.html ) 