### PR TITLE
ignore also `vendor-bin/*/composer.lock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /vendor-bin/*/vendor/
 /build/
 /composer.lock
+/vendor-bin/*/composer.lock
 /phpunit.xml
 /.phpunit.result.cache
 /.phpcs-cache


### PR DESCRIPTION
I think `/vendor-bin/*/composer.lock` also should be git-ignored by default.