### PR TITLE
Add PHPUnit Path Coverage config as comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /composer.lock
 /phpunit.xml
 /.phpunit.result.cache
+/.phpunit.cache/
 /.phpcs-cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+        processUncoveredFiles="true"
+        pathCoverage="true">
         <include>
             <directory suffix=".php">src</directory>
         </include>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,9 +9,11 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-        processUncoveredFiles="true"
-        pathCoverage="true">
+    <coverage processUncoveredFiles="true">
+<!--    If you want to enable pathCoverage, use this.-->
+<!--    <coverage cacheDirectory=".phpunit.cache/code-coverage"-->
+<!--        processUncoveredFiles="true"-->
+<!--        pathCoverage="true">-->
         <include>
             <directory suffix=".php">src</directory>
         </include>


### PR DESCRIPTION
`pathCoverage` was enabled in 1.1.11. See #69
But for some reason it's gone in 1.1.12.

It seems only Xdebug supports this feature. So I put the config as comments.
https://github.com/koriym/Koriym.PhpSkeleton/discussions/74#discussioncomment-1006798
