### PR TITLE
Add PHP version testing with GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,49 @@
+name: Continuous Integration
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+        php-version:
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: none
+          ini-values: assert.exception=1, zend.assertions=1
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run test suite
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Introduce CI workflow for testing PHP versions 8.1, 8.2, 8.3, 8.4 on Ubuntu to ensure reliable testing for all supported environments.

---

- [ ] Tests added for PHP versions 8.1, 8.2, 8.3, 8.4
- [ ] CI workflow set up for PHP version testing
- [ ] PHPUnit test suite running successfully

## Sourcery によるサマリー

CI:
- PHP バージョン 8.1, 8.2, 8.3, および 8.4 をテストするための新しい CI ワークフローを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a new CI workflow to test PHP versions 8.1, 8.2, 8.3, and 8.4.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Implemented an automated quality assurance system that tests our application across various environments, ensuring enhanced compatibility, stability, and performance. This improvement strengthens our development workflow to catch issues early and deliver a more robust user experience.
  - Automated testing now runs with each update, proactively safeguarding seamless performance and further boosting the reliability of our service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->