### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a single-line command that will automatically setup for
 It will automatically install the following dependencies:
 
 * [PHPUnit](https://phpunit.readthedocs.io/ja/latest/): provides testing framework.
-* [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/wiki): detects violations of a defined set of coding standards.
+* [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki): detects violations of a defined set of coding standards.
 * [PHPMD](https://phpmd.org): analyze your code to detect sub-optimal or overly complex code.
 * [PHPStan](https://phpmd.org): discover bugs in your code without running it.
 * [Psalm](https://psalm.dev): - another static analysis tool from Vimeo.


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dependency reference links.
  * Added information about mutation testing and composer dependency validation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->