### PR TITLE
Drop php 8.1 and support php 8.5

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       php_version:
-        default: '8.4'
+        default: '8.5'
+        description: 'PHP version to use'
 jobs:
   coding-standards:
     name: Coding Standards

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,6 @@ jobs:
         operating-system:
           - ubuntu-latest
         php-version:
-          - '8.1'
           - '8.2'
           - '8.3'
           - '8.4'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: pcov
           ini-values: memory_limit=-1
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       php_version:
-        default: '8.4'
+        default: '8.5'
+        description: 'PHP version to use'
 
 jobs:
   static-analysis-phpstan:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",
         "composer/composer": "^2.8",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^11.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,11 +9,11 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
-            <directory suffix=".php">src</directory>
+            <directory>src</directory>
         </include>
-    </coverage>
+    </source>
     <php>
         <ini name="error_reporting" value="-1"/>
     </php>

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -1,7 +1,7 @@
 {
     "require-dev": {
         "doctrine/coding-standard": "^14.0",
-        "infection/infection": "^0.31",
+        "infection/infection": "^0.33",
         "phpmd/phpmd": "^2.15",
         "pdepend/pdepend": "^2.16",
         "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
## Summary

* Drop PHP 8.1
* Update phpunit to v11.5
* Update infection/infection to v0.33
* Add PHP 8.5 to CI workflow and default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP version requirement to 8.2
  * Updated CI/testing workflows to use PHP 8.5 and removed PHP 8.1 support
  * Upgraded PHPUnit and mutation testing tool dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->