### PR TITLE
Add VENDOR/PACKAGE env var support and enhance PHPMD configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ What is your email address ?
 (akihito.koriyama@gmail.com):
 ```
 
+You can also skip the prompts by setting environment variables:
+
+```
+VENDOR=MyVendor PACKAGE=MyPackage composer create-project koriym/php-skeleton <project-path>
+```
+
 ## Composer Commands
 
 Once installed, the project will automatically be configured, so you can run these commands in the root of your application:

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -53,7 +53,7 @@
         <properties>
             <!-- Weighted Method Count (WMC) threshold (default=50)
                  Recommended values: strict=30, normal=50, easy=80 -->
-            <property name="maximum" value="100"/>
+            <property name="maximum" value="80"/>
         </properties>
     </rule>
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -8,33 +8,51 @@
     <!-- Clean Code Rules -->
     <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
     <rule ref="rulesets/cleancode.xml/ElseExpression"/>
+    <rule ref="rulesets/cleancode.xml/IfStatementAssignment"/>
+    <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey"/>
+    <rule ref="rulesets/cleancode.xml/ErrorControlOperator"/>
     <!-- <rule ref="rulesets/cleancode.xml/StaticAccess"/> -->
-    <!-- <rule ref="rulesets/cleancode.xml/IfStatementAssignment"/> -->
-    <!-- <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey"/> -->
-    <!-- <rule ref="rulesets/cleancode.xml/MissingImport"/> -->
-    <!-- <rule ref="rulesets/cleancode.xml/UndefinedVariable"/> -->
-    <!-- <rule ref="rulesets/cleancode.xml/ErrorControlOperator"/> -->
+    <!-- <rule ref="rulesets/cleancode.xml/MissingImport"/> --> <!-- Covered by PHPCS -->
+    <!-- <rule ref="rulesets/cleancode.xml/UndefinedVariable"/> --> <!-- Covered by PHPStan/Psalm -->
 
     <!-- Code Size Rules -->
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
         <properties>
+            <!-- Cyclomatic complexity threshold (default=10)
+                 Recommended values: strict=10, normal=20, easy=30 -->
             <property name="reportLevel" value="20"/>
         </properties>
     </rule>
     <rule ref="rulesets/codesize.xml/NPathComplexity">
         <properties>
+            <!-- NPath complexity threshold (default=200)
+                 Recommended values: strict=100, normal=200, easy=300 -->
             <property name="minimum" value="200"/>
         </properties>
     </rule>
+    <!-- Maximum lines per method (default=100)
+         Recommended values: strict=50, normal=100, easy=150 -->
     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
+    <!-- Maximum lines per class (default=1000)
+         Recommended values: strict=500, normal=1000, easy=1500 -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>
+    <!-- Maximum parameters per method (default=10)
+         Recommended values: strict=5, normal=10, easy=15 -->
     <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
+    <!-- Maximum public methods per class (default=45)
+         Recommended values: strict=30, normal=45, easy=60 -->
     <rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
+    <!-- Maximum fields per class (default=15)
+         Recommended values: strict=10, normal=15, easy=20 -->
     <rule ref="rulesets/codesize.xml/TooManyFields"/>
+    <!-- Maximum methods per class (default=25, ignores get/set methods)
+         Recommended values: strict=15, normal=25, easy=40 -->
     <rule ref="rulesets/codesize.xml/TooManyMethods"/>
-    <rule ref="rulesets/codesize.xml/TooManyPublicMethods"/>
+    <!-- <rule ref="rulesets/codesize.xml/TooManyPublicMethods"/> --> <!-- default=10, ignores get/set -->
     <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
         <properties>
+            <!-- Weighted Method Count (WMC) threshold (default=50)
+                 Recommended values: strict=30, normal=50, easy=80 -->
             <property name="maximum" value="100"/>
         </properties>
     </rule>
@@ -43,35 +61,50 @@
     <rule ref="rulesets/controversial.xml/CamelCaseClassName"/>
     <rule ref="rulesets/controversial.xml/CamelCasePropertyName"/>
     <rule ref="rulesets/controversial.xml/CamelCaseMethodName"/>
-    <!-- <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/> -->
-    <!-- <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/> -->
-    <!-- <rule ref="rulesets/controversial.xml/Superglobals"/> -->
+    <rule ref="rulesets/controversial.xml/Superglobals"/>
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/> --> <!-- Covered by PHPCS -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/> --> <!-- Covered by PHPCS -->
 
     <!-- Design Rules -->
     <rule ref="rulesets/design.xml/EvalExpression"/>
     <rule ref="rulesets/design.xml/ExitExpression"/>
     <rule ref="rulesets/design.xml/GotoStatement"/>
+    <!-- Maximum number of child classes (default=15)
+         Recommended values: strict=10, normal=15, easy=20 -->
     <rule ref="rulesets/design.xml/NumberOfChildren"/>
+    <!-- Maximum depth of inheritance tree (default=6)
+         Recommended values: strict=4, normal=6, easy=8 -->
     <rule ref="rulesets/design.xml/DepthOfInheritance"/>
-    <!-- <rule ref="rulesets/design.xml/CouplingBetweenObjects"/> -->
-    <!-- <rule ref="rulesets/design.xml/DevelopmentCodeFragment"/> -->
-    <!-- <rule ref="rulesets/design.xml/EmptyCatchBlock"/> -->
-    <!-- <rule ref="rulesets/design.xml/CountInLoopExpression"/> -->
+    <rule ref="rulesets/design.xml/CouplingBetweenObjects">
+        <properties>
+            <!-- Counts dependencies via properties, parameters, exceptions (default=13)
+                 Recommended values: strict=13, normal=15, easy=25 -->
+            <property name="maximum" value="15"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/design.xml/DevelopmentCodeFragment"/>
+    <rule ref="rulesets/design.xml/EmptyCatchBlock"/>
+    <rule ref="rulesets/design.xml/CountInLoopExpression"/>
 
     <!-- Naming Rules -->
     <rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
     <rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
-    <!-- <rule ref="rulesets/naming.xml/LongClassName"/> -->
-    <!-- <rule ref="rulesets/naming.xml/ShortClassName"/> -->
+    <!-- Maximum characters in class name (default=40)
+         Recommended values: strict=30, normal=40, easy=50 -->
+    <rule ref="rulesets/naming.xml/LongClassName"/>
+    <!-- Maximum characters in variable name (default=20)
+         Recommended values: strict=15, normal=20, easy=30 -->
+    <rule ref="rulesets/naming.xml/LongVariable"/>
+    <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
+    <!-- Minimum characters in variable name (default=3)
+         Recommended values: strict=3, normal=3, easy=2 -->
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
-            <!-- Allow common loop counters and short variables -->
             <property name="exceptions" value="i,j,k,id,to,db,io" />
         </properties>
     </rule>
-    <!-- <rule ref="rulesets/naming.xml/LongVariable"/> -->
-    <!-- <rule ref="rulesets/naming.xml/ShortMethodName"/> -->
-    <!-- <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/> -->
+    <!-- <rule ref="rulesets/naming.xml/ShortClassName"/> --> <!-- default minimum=3 -->
+    <!-- <rule ref="rulesets/naming.xml/ShortMethodName"/> --> <!-- default minimum=3 -->
 
     <!-- Unused Code Rules -->
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -19,7 +19,9 @@ use function date;
 use function dirname;
 use function file_get_contents;
 use function file_put_contents;
+use function getenv;
 use function is_callable;
+use function is_string;
 use function is_writable;
 use function lcfirst;
 use function passthru;
@@ -51,10 +53,9 @@ final class Installer
 
     public static function preInstall(Event $event): void
     {
-        $pacakageNameValidator = self::getValidator();
         $io = $event->getIO();
-        $vendorClass = self::ask($io, 'What is the vendor name?', 'MyVendor', $pacakageNameValidator);
-        $packageClass = self::ask($io, 'What is the package name?', 'MyPackage', $pacakageNameValidator);
+        $vendorClass = self::getVendorName($io);
+        $packageClass = self::getPackageName($io);
         self::$userName = self::ask($io, 'What is your name?', self::getUserName());
         self::$userEmail = self::ask($io, 'What is your email address ?', self::getUserEmail());
         self::$packageName = sprintf('%s/%s', self::camel2dashed($vendorClass), self::camel2dashed($packageClass));
@@ -63,6 +64,26 @@ final class Installer
         self::$appName = [$vendorClass, $packageClass];
         // Update composer definition
         $json->write($composerDefinition);
+    }
+
+    private static function getVendorName(IOInterface $io): string
+    {
+        $envVendor = getenv('VENDOR');
+        if (is_string($envVendor) && $envVendor !== '') {
+            return ucfirst($envVendor);
+        }
+
+        return self::ask($io, 'What is the vendor name?', 'MyVendor', self::getValidator());
+    }
+
+    private static function getPackageName(IOInterface $io): string
+    {
+        $envPackage = getenv('PACKAGE');
+        if (is_string($envPackage) && $envPackage !== '') {
+            return ucfirst($envPackage);
+        }
+
+        return self::ask($io, 'What is the package name?', 'MyPackage', self::getValidator());
     }
 
     private static function getValidator(): callable

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -70,7 +70,9 @@ final class Installer
     {
         $envVendor = getenv('VENDOR');
         if (is_string($envVendor) && $envVendor !== '') {
-            return ucfirst($envVendor);
+            $validator = self::getValidator();
+
+            return $validator($envVendor);
         }
 
         return self::ask($io, 'What is the vendor name?', 'MyVendor', self::getValidator());
@@ -80,7 +82,9 @@ final class Installer
     {
         $envPackage = getenv('PACKAGE');
         if (is_string($envPackage) && $envPackage !== '') {
-            return ucfirst($envPackage);
+            $validator = self::getValidator();
+
+            return $validator($envPackage);
         }
 
         return self::ask($io, 'What is the package name?', 'MyPackage', self::getValidator());


### PR DESCRIPTION
## Summary

Two improvements for the skeleton installer:

### 1. Non-interactive install via environment variables (`ae0f33d`)

Allow `VENDOR=` and `PACKAGE=` environment variables to skip interactive prompts, matching BEAR.Skeleton's `Install.php` pattern.

Usage:
```
VENDOR=MyVendor PACKAGE=MyPackage composer create-project koriym/php-skeleton path
```

### 2. Enhanced PHPMD configuration (`fb920e7`)

- Enable 11 additional rules (IfStatementAssignment, Superglobals, CouplingBetweenObjects, etc.)
- Disable TooManyPublicMethods (redundant with TooManyMethods)
- Add strict/normal/easy recommended values from official PHPMD docs as inline comments
- Add explanatory comments for disabled rules (covered by PHPCS/PHPStan/Psalm)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now supports fully automated setup by accepting vendor and package names from `VENDOR` and `PACKAGE` environment variables, avoiding interactive prompts.
  * Project creation instructions now document how to use `VENDOR` and `PACKAGE` to skip prompts.
* **Chores**
  * Updated code quality analysis configuration by enabling/disabling PHPMD rules and refining related threshold documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->